### PR TITLE
Fix double-rendering in globe and typo in an env variable

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       - SMTP_USER=any
       - SMTP_PASS=any
       - SMTP_FROM=TFG <noreply@tfg.local>
-      - FLIGHT_CACHE_TTL_HOURS=${FLIGHT_CACHE_TTL_HOURS: -24}
+      - FLIGHT_CACHE_TTL_HOURS=${FLIGHT_CACHE_TTL_HOURS:-24}
 
   website:
     build:


### PR DESCRIPTION
Catched the reference of globe to clean up correctly when destroyed since React renders all components twice when it's in strict mode.
Added min and max distance to limit when approaching and moving away the globe.
Added cursor pointer for markers (airports)
Removed extra space in value of a env variable