### PR TITLE
Potential fix for code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -143,7 +143,7 @@ app.use((err: any, req: express.Request, res: express.Response, next: express.Ne
 
     // Errores INTERNOS no capturados
     if (err instanceof Error) {
-        console.error(`Unhandled Error on path ${req.path}:\n`, err);
+        console.error('Unhandled Error on path %s:\n', req.path, err);
         return res.status(500).json({
             status: 'error',
             message: 'Internal Server Error',


### PR DESCRIPTION
Potential fix for [https://github.com/RubizZ/flAIghts/security/code-scanning/3](https://github.com/RubizZ/flAIghts/security/code-scanning/3)

In general, to fix format-string issues with untrusted input, avoid embedding the untrusted value directly into the format string. Instead, use a fixed, constant format string (for example, with `%s` placeholders) and pass the untrusted value as a separate argument. This ensures that any `%` characters in the untrusted data are printed literally instead of being interpreted as format specifiers.

For this specific case in `backend/src/index.ts`, line 146 currently uses a template literal including `req.path` as the first argument to `console.error`:

```ts
console.error(`Unhandled Error on path ${req.path}:\n`, err);
```

To fix it without changing behavior, we should make the first argument a static format string and supply `req.path` as another argument. One idiomatic change is:

```ts
console.error('Unhandled Error on path %s:\n', req.path, err);
```

This preserves the log message content and structure, but prevents `req.path` from being part of the format string itself. No new imports or helpers are needed; the change is localized to that line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
