### PR TITLE
Potential fix for code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -125,7 +125,7 @@ app.use((err: any, req: express.Request, res: express.Response, next: express.Ne
     // Errores de NEGOCIO: errores del servicio
     // Incluye lógica de negocio, conflictos, recursos no encontrados, etc.
     if (err instanceof AppError) {
-        console.log(`AppError on path ${req.path}:\n`, err);
+        console.log('AppError on path %s:\n', req.path, err);
         return res.status(err.statusCode).json({
             status: 'fail',
             data: err.toJSON()


### PR DESCRIPTION
Potential fix for [https://github.com/RubizZ/flAIghts/security/code-scanning/2](https://github.com/RubizZ/flAIghts/security/code-scanning/2)

General approach: Ensure that user-controlled data (`req.path`) is never interpolated directly into the format string that is the first argument of `console.log`. Instead, use a constant format string with `%s` placeholders and pass `req.path` as a separate argument. This aligns exactly with the recommended mitigation pattern: “use a `%s` specifier in the format string, and pass the untrusted data as a corresponding argument.”

Concrete fix in this file: On line 128, replace the template literal `` `AppError on path ${req.path}:\n` `` with a constant string that contains a `%s` placeholder, and pass `req.path` as an additional argument in the `console.log` call. For example, change:

```ts
console.log(`AppError on path ${req.path}:\n`, err);
```

to:

```ts
console.log('AppError on path %s:\n', req.path, err);
```

This preserves existing functionality (same information in the logs, same error object printed) while ensuring the format string is not influenced by untrusted input. No additional imports or helper functions are required; we only adjust this logging call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
