### PR TITLE
Pagination for airline and airport search endpoints

### DIFF
--- a/backend/src/modules/airline/airline.controller.ts
+++ b/backend/src/modules/airline/airline.controller.ts
@@ -3,6 +3,7 @@ import { injectable, inject } from "tsyringe";
 import { AirlineService } from "./airline.service.js";
 import type { SuccessResponse as SuccessResponseType, RequestValidationFailResponse, ValidationDetails, QueryPath } from "../../utils/responses.js";
 import type { PaginatedAirlineResponse } from "./airline.types.js";
+
 @injectable()
 @Route("airlines")
 @Tags("Airlines")
@@ -10,6 +11,7 @@ export class AirlineController extends Controller {
     constructor(@inject(AirlineService) private airlineService: AirlineService) {
         super();
     }
+
     @Get("/")
     @SuccessResponse(200, "Aerolineas encontradas")
     @Response<RequestValidationFailResponse<ValidationDetails<QueryPath<{ q: string }>>>>(422, "Error de validación")

--- a/backend/src/modules/airline/airline.controller.ts
+++ b/backend/src/modules/airline/airline.controller.ts
@@ -1,8 +1,8 @@
-import { Controller, Get, Route, Query, Tags, Response } from "tsoa"
+import { Controller, Get, Route, Query, Tags, Response, SuccessResponse } from "tsoa"
 import { injectable, inject } from "tsyringe";
 import { AirlineService } from "./airline.service.js";
-import type { SuccessResponse, RequestValidationFailResponse, ValidationDetails, QueryPath } from "../../utils/responses.js";
-import type { AirlineResponse } from "./airline.types.js";
+import type { SuccessResponse as SuccessResponseType, RequestValidationFailResponse, ValidationDetails, QueryPath } from "../../utils/responses.js";
+import type { PaginatedAirlineResponse } from "./airline.types.js";
 @injectable()
 @Route("airlines")
 @Tags("Airlines")
@@ -11,10 +11,10 @@ export class AirlineController extends Controller {
         super();
     }
     @Get("/")
-    @Response<SuccessResponse<AirlineResponse[]>>(200, "Aerolineas encontradas")
+    @SuccessResponse(200, "Aerolineas encontradas")
     @Response<RequestValidationFailResponse<ValidationDetails<QueryPath<{ q: string }>>>>(422, "Error de validación")
-    public async searchAirlines(@Query() q: string): Promise<SuccessResponse<AirlineResponse[]>> {
-        const airlines = await this.airlineService.searchAirlines(q);
-        return airlines satisfies AirlineResponse[] as any;
+    public async searchAirlines(@Query() q: string, @Query() page: number = 1, @Query() limit: number = 10): Promise<SuccessResponseType<PaginatedAirlineResponse>> {
+        const airlines = await this.airlineService.searchAirlines(q, page, limit);
+        return airlines satisfies PaginatedAirlineResponse as any;
     }
 }

--- a/backend/src/modules/airline/airline.service.ts
+++ b/backend/src/modules/airline/airline.service.ts
@@ -1,21 +1,39 @@
 import { singleton } from "tsyringe";
 import { Airline } from "./airline.model.js";
-import type { AirlineResponse } from "./airline.types.js";
+import type { PaginatedAirlineResponse } from "./airline.types.js";
 
 @singleton()
 export class AirlineService {
-    public async searchAirlines(query: string): Promise<AirlineResponse[]> {
-        if (!query || query.length < 2) return [];
+    public async searchAirlines(query: string, page: number = 1, limit: number = 10): Promise<PaginatedAirlineResponse> {
+        if (!query || query.length < 2) {
+            return { items: [], total: 0, page, totalPages: 0 };
+        }
 
         const regex = new RegExp(query, 'i');
 
-        const airlines = await Airline.find({
+        const findQuery = {
             $or: [
                 { name: regex },
                 { code: regex }
             ]
-        }).sort({ quality_score: -1 }).limit(10).lean();
+        };
 
-        return airlines;
+        const skip = (page - 1) * limit;
+
+        const [airlines, total] = await Promise.all([
+            Airline.find(findQuery)
+                .sort({ quality_score: -1 })
+                .skip(skip)
+                .limit(limit)
+                .lean(),
+            Airline.countDocuments(findQuery)
+        ]);
+
+        return {
+            items: airlines,
+            total,
+            page,
+            totalPages: Math.ceil(total / limit)
+        };
     }
 }

--- a/backend/src/modules/airline/airline.types.ts
+++ b/backend/src/modules/airline/airline.types.ts
@@ -4,3 +4,10 @@ export interface AirlineResponse {
     country: string;
     quality_score: number;
 }
+
+export interface PaginatedAirlineResponse {
+    items: AirlineResponse[];
+    total: number;
+    page: number;
+    totalPages: number;
+}

--- a/backend/src/modules/airport/airport.controller.ts
+++ b/backend/src/modules/airport/airport.controller.ts
@@ -1,8 +1,8 @@
-import { Controller, Get, Route, Query, Tags, Response } from "tsoa";
+import { Controller, Get, Route, Query, Tags, Response, SuccessResponse } from "tsoa";
 import { injectable, inject } from "tsyringe";
 import { AirportService } from "./airport.service.js";
-import type { AirportResponse, GlobeAirportResponse } from "./airport.types.js";
-import type { SuccessResponse, RequestValidationFailResponse, ValidationDetails, QueryPath } from "../../utils/responses.js";
+import type { PaginatedAirportResponse, GlobeAirportResponse } from "./airport.types.js";
+import type { SuccessResponse as SuccessResponseType, RequestValidationFailResponse, ValidationDetails, QueryPath } from "../../utils/responses.js";
 
 @injectable()
 @Route("airports")
@@ -14,15 +14,19 @@ export class AirportController extends Controller {
     }
 
     @Get("/")
-    @Response<SuccessResponse<AirportResponse[]>>(200, "Aeropuertos encontrados")
+    @SuccessResponse(200, "Aeropuertos encontrados")
     @Response<RequestValidationFailResponse<ValidationDetails<QueryPath<{ q: string }>>>>(422, "Error de validación")
-    public async searchAirports(@Query() q: string): Promise<SuccessResponse<AirportResponse[]>> {
-        const results = await this.airportService.searchAirports(q);
-        return results as any;
+    public async searchAirports(
+        @Query() q: string,
+        @Query() page: number = 1,
+        @Query() limit: number = 10
+    ): Promise<SuccessResponseType<PaginatedAirportResponse>> {
+        const results = await this.airportService.searchAirports(q, page, limit);
+        return results satisfies PaginatedAirportResponse as any;
     }
 
     @Get("/globe")
-    @Response<GlobeAirportResponse[]>(200, "Aeropuertos para el globo")
+    @SuccessResponse(200, "Aeropuertos para el globo")
     public async getGlobeAirports(): Promise<GlobeAirportResponse[]> {
         return this.airportService.getGlobeAirports();
     }

--- a/backend/src/modules/airport/airport.controller.ts
+++ b/backend/src/modules/airport/airport.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Route, Query, Tags, Response, SuccessResponse } from "tsoa";
 import { injectable, inject } from "tsyringe";
 import { AirportService } from "./airport.service.js";
-import type { PaginatedAirportResponse, GlobeAirportResponse } from "./airport.types.js";
+import type { AirportResponse, PaginatedAirportResponse, GlobeAirportResponse } from "./airport.types.js";
 import type { SuccessResponse as SuccessResponseType, RequestValidationFailResponse, ValidationDetails, QueryPath } from "../../utils/responses.js";
 
 @injectable()
@@ -33,8 +33,8 @@ export class AirportController extends Controller {
     }
 
     @Get("/{iata}")
-    @Response<SuccessResponse<AirportResponse>>(200, "Aeropuerto encontrado")
-    public async getAirportByIata(iata: string): Promise<SuccessResponse<AirportResponse>> {
+    @SuccessResponse(200, "Aeropuerto encontrado")
+    public async getAirportByIata(iata: string): Promise<SuccessResponseType<AirportResponse>> {
         const result = await this.airportService.getAirportByIata(iata);
         if (!result) {
             this.setStatus(404);

--- a/backend/src/modules/airport/airport.controller.ts
+++ b/backend/src/modules/airport/airport.controller.ts
@@ -27,8 +27,9 @@ export class AirportController extends Controller {
 
     @Get("/globe")
     @SuccessResponse(200, "Aeropuertos para el globo")
-    public async getGlobeAirports(): Promise<GlobeAirportResponse[]> {
-        return this.airportService.getGlobeAirports();
+    public async getGlobeAirports(): Promise<SuccessResponseType<GlobeAirportResponse[]>> {
+        const airports = await this.airportService.getGlobeAirports();
+        return airports satisfies GlobeAirportResponse[] as any;
     }
 
     @Get("/{iata}")

--- a/backend/src/modules/airport/airport.service.ts
+++ b/backend/src/modules/airport/airport.service.ts
@@ -60,15 +60,17 @@ export class AirportService {
     /**
      * Búsqueda con detección de errores (typos) usando fuzzysort y normalización
      */
-    public async searchAirports(query: string): Promise<AirportResponse[]> {
+    public async searchAirports(query: string, page: number = 1, limit: number = 10): Promise<PaginatedAirportResponse> {
         if (!this.isInitialized) {
             // Fallback si por alguna razón no está listo (aunque es poco probable)
-            const results = await this.searchDatabase(query);
+            const results = await this.searchDatabase(query, page, limit);
             return results;
         }
 
         const cleanQuery = query?.trim();
-        if (!cleanQuery || cleanQuery.length < 2) return [];
+        if (!cleanQuery || cleanQuery.length < 2) {
+            return { items: [], total: 0, page, totalPages: 0 };
+        }
 
         // Normalizamos la query para que coincida con nuestros campos normalizados
         const normalizedQuery = this.normalize(cleanQuery);
@@ -76,11 +78,10 @@ export class AirportService {
         // Fuzzysort en los campos normalizados
         const results = fuzzysort.go(normalizedQuery, this.airportsCache, {
             keys: ['_normIata', '_normCity', '_normName', '_normCountry', '_normCountryNames'],
-            limit: 15,
             threshold: -10000, // Ajustable según sensibilidad deseada
         });
 
-        return results.map(result => {
+        const sortedResults = results.map((result: any) => {
             const airport = result.obj;
             // Calculamos un bonus basado en importancia y precisión de fuzzysort
             // result.score es negativo (0 es match perfecto)
@@ -92,17 +93,44 @@ export class AirportService {
             }
 
             return { ...airport, _sortScore: finalScore };
-        }).sort((a, b) => b._sortScore - a._sortScore)
-            .slice(0, 10)
+        }).sort((a, b) => b._sortScore - a._sortScore);
+
+        const total = sortedResults.length;
+        const paginatedItems = sortedResults
+            .slice((page - 1) * limit, page * limit)
             .map(({ _sortScore, searchKey, ...airport }) => airport as any);
+
+        return {
+            items: paginatedItems,
+            total,
+            page,
+            totalPages: Math.ceil(total / limit)
+        };
     }
 
-    private async searchDatabase(query: string) {
+    private async searchDatabase(query: string, page: number = 1, limit: number = 10): Promise<PaginatedAirportResponse> {
         // Fallback básico si la caché falla
         const regex = new RegExp(query, 'i');
-        return await Airport.find({
+        const findQuery = {
             $or: [{ iata_code: regex }, { city: regex }, { name: regex }]
-        }).limit(10).lean() as any;
+        };
+
+        const skip = (page - 1) * limit;
+
+        const [airports, total] = await Promise.all([
+            Airport.find(findQuery)
+                .skip(skip)
+                .limit(limit)
+                .lean(),
+            Airport.countDocuments(findQuery)
+        ]);
+
+        return {
+            items: airports as AirportResponse[],
+            total,
+            page,
+            totalPages: Math.ceil(total / limit)
+        };
     }
 
     /**

--- a/backend/src/modules/airport/airport.service.ts
+++ b/backend/src/modules/airport/airport.service.ts
@@ -1,7 +1,7 @@
 import { singleton } from "tsyringe";
 import fuzzysort from "fuzzysort";
 import { Airport, type IAirport } from "./airport.model.js";
-import type { AirportResponse, ScoredAirport, GlobeAirportResponse } from "./airport.types.js";
+import type { AirportResponse, PaginatedAirportResponse, ScoredAirport, GlobeAirportResponse } from "./airport.types.js";
 
 // Radios base (km) para búsqueda de rutas
 const MIN_RADIUS_KM = 150;

--- a/backend/src/modules/airport/airport.types.ts
+++ b/backend/src/modules/airport/airport.types.ts
@@ -16,6 +16,13 @@ export interface ScoredAirport {
   score: number;
 }
 
+export interface PaginatedAirportResponse {
+    items: AirportResponse[];
+    total: number;
+    page: number;
+    totalPages: number;
+}
+
 /**
  * Compact format for globe visualization
  */

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -4224,7 +4224,31 @@
         "type": "object",
         "additionalProperties": false
       },
-      "SuccessResponse_AirportResponse_": {
+      "SuccessResponseType_GlobeAirportResponse-Array_": {
+        "description": "Wrapper de éxito JSend (aplicado por el middleware global).",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "success"
+            ],
+            "nullable": false
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/GlobeAirportResponse"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "status",
+          "data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "SuccessResponseType_AirportResponse_": {
         "description": "Wrapper de éxito JSend (aplicado por el middleware global).",
         "properties": {
           "status": {
@@ -6093,11 +6117,11 @@
         "operationId": "GetAirportByIata",
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "Aeropuerto encontrado",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse_AirportResponse_"
+                  "$ref": "#/components/schemas/SuccessResponseType_AirportResponse_"
                 }
               }
             }

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -4133,7 +4133,37 @@
         "type": "object",
         "additionalProperties": false
       },
-      "SuccessResponse_AirportResponse-Array_": {
+      "PaginatedAirportResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AirportResponse"
+            },
+            "type": "array"
+          },
+          "total": {
+            "type": "number",
+            "format": "double"
+          },
+          "page": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalPages": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "totalPages"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "SuccessResponseType_PaginatedAirportResponse_": {
         "description": "Wrapper de éxito JSend (aplicado por el middleware global).",
         "properties": {
           "status": {
@@ -4144,10 +4174,7 @@
             "nullable": false
           },
           "data": {
-            "items": {
-              "$ref": "#/components/schemas/AirportResponse"
-            },
-            "type": "array"
+            "$ref": "#/components/schemas/PaginatedAirportResponse"
           }
         },
         "required": [
@@ -4243,7 +4270,37 @@
         "type": "object",
         "additionalProperties": false
       },
-      "SuccessResponse_AirlineResponse-Array_": {
+      "PaginatedAirlineResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AirlineResponse"
+            },
+            "type": "array"
+          },
+          "total": {
+            "type": "number",
+            "format": "double"
+          },
+          "page": {
+            "type": "number",
+            "format": "double"
+          },
+          "totalPages": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "totalPages"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "SuccessResponseType_PaginatedAirlineResponse_": {
         "description": "Wrapper de éxito JSend (aplicado por el middleware global).",
         "properties": {
           "status": {
@@ -4254,10 +4311,7 @@
             "nullable": false
           },
           "data": {
-            "items": {
-              "$ref": "#/components/schemas/AirlineResponse"
-            },
-            "type": "array"
+            "$ref": "#/components/schemas/PaginatedAirlineResponse"
           }
         },
         "required": [
@@ -5956,11 +6010,11 @@
         "operationId": "SearchAirports",
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "Aeropuertos encontrados",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse_AirportResponse-Array_"
+                  "$ref": "#/components/schemas/SuccessResponseType_PaginatedAirportResponse_"
                 }
               }
             }
@@ -5988,6 +6042,26 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "format": "double",
+              "type": "number"
+            }
           }
         ]
       }
@@ -5997,14 +6071,11 @@
         "operationId": "GetGlobeAirports",
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "Aeropuertos para el globo",
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GlobeAirportResponse"
-                  },
-                  "type": "array"
+                  "$ref": "#/components/schemas/SuccessResponseType_GlobeAirportResponse-Array_"
                 }
               }
             }
@@ -6053,11 +6124,11 @@
         "operationId": "SearchAirlines",
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "Aerolineas encontradas",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse_AirlineResponse-Array_"
+                  "$ref": "#/components/schemas/SuccessResponseType_PaginatedAirlineResponse_"
                 }
               }
             }
@@ -6084,6 +6155,26 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "format": "double",
+              "type": "number"
             }
           }
         ]

--- a/frontend/src/components/AirportAutocomplete.tsx
+++ b/frontend/src/components/AirportAutocomplete.tsx
@@ -25,7 +25,7 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
     const [query, setQuery] = useState(getDisplay(value));
     const [debouncedQuery, setDebouncedQuery] = useState("");
     const [isOpen, setIsOpen] = useState(false);
-
+    const [showFlatList, setShowFlatList] = useState(false);
     const sentinelRef = useRef<HTMLDivElement>(null);
     const scrollContainerRef = useRef<HTMLUListElement>(null);
 
@@ -69,11 +69,14 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
 
     const suggestions = useMemo(() => data?.pages.flatMap(page => page.items) ?? [], [data]);
 
+    // Use only the first page for the initial grouped view to avoid fragmentation during pagination
+    const firstPageSuggestions = useMemo(() => data?.pages[0]?.items ?? [], [data]);
+
     const groupedSuggestions = useMemo(() => {
         const groups: Record<string, AirportResponse[]> = {};
         const countryOrder: string[] = [];
 
-        suggestions.forEach(airport => {
+        firstPageSuggestions.forEach(airport => {
             const countryCode = airport.country || "Otros";
             const countryName = (COUNTRY_NAMES[countryCode] && COUNTRY_NAMES[countryCode][1]) || countryCode;
 
@@ -85,7 +88,7 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
         });
 
         return countryOrder.map(name => [name, groups[name]] as [string, AirportResponse[]]);
-    }, [suggestions]);
+    }, [firstPageSuggestions]);
 
     // Sync input with external value
     useEffect(() => {
@@ -94,18 +97,20 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
         }
     }, [value, isOpen]);
 
-    // Debounce query
+    // Debounce query and reset to group view when query changes
     useEffect(() => {
         const timer = setTimeout(() => {
             if (isOpen || !value) {
                 setDebouncedQuery(query);
             }
+            setShowFlatList(false);
         }, 300);
         return () => clearTimeout(timer);
     }, [query, isOpen, value]);
 
-    // Infinite Scroll Observer
+    // Infinite Scroll Observer (only in flat view)
     useEffect(() => {
+        if (!showFlatList) return;
         const observer = new IntersectionObserver((entries) => {
             if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
                 fetchNextPage();
@@ -117,7 +122,7 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
         const el = sentinelRef.current;
         if (el) observer.observe(el);
         return () => { if (el) observer.unobserve(el); };
-    }, [hasNextPage, isFetchingNextPage, fetchNextPage, suggestions, scrollContainerRef.current]);
+    }, [hasNextPage, isFetchingNextPage, fetchNextPage, suggestions, scrollContainerRef.current, showFlatList]);
 
     const handleSelect = (airport: AirportResponse) => {
         const result = onChange(airport);
@@ -180,44 +185,79 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
             }
         >
             <ul ref={scrollContainerRef} className="flex flex-col max-h-[400px] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
-                {groupedSuggestions.length > 0 ? (
-                    groupedSuggestions.map(([country, airports]) => (
-                        <div key={country} className="flex flex-col border-b border-line last:border-0">
-                            <div className="sticky top-0 z-10 bg-surface/95 backdrop-blur-md px-4 py-2 border-b border-line flex items-center">
-                                <span className="text-[10px] font-bold uppercase tracking-[0.2em] text-content/50 pr-3 border-r border-line mr-3 leading-none">
-                                    {country}
-                                </span>
+                {/* Grouped view (first page only) */}
+                {!showFlatList && groupedSuggestions.length > 0 && (
+                    <>
+                        {groupedSuggestions.map(([country, airports]) => (
+                            <div key={country} className="flex flex-col border-b border-line last:border-0">
+                                <div className="sticky top-0 z-10 bg-surface/95 backdrop-blur-md px-4 py-2 border-b border-line flex items-center">
+                                    <span className="text-[10px] font-bold uppercase tracking-[0.2em] text-content/50 pr-3 border-r border-line mr-3 leading-none">
+                                        {country}
+                                    </span>
+                                </div>
+                                {airports.map((airport) => (
+                                    <li
+                                        key={airport.iata_code}
+                                        className="px-4 py-3 hover:bg-surface transition-all cursor-pointer flex items-center gap-3 border-b border-line/40 last:border-0 group/suggestion"
+                                        onClick={() => handleSelect(airport)}
+                                    >
+                                        <div className="bg-surface/50 p-2 rounded-xl shrink-0 group-hover/suggestion:bg-brand/10 transition-colors">
+                                            <Plane size={16} className="text-content-muted/60 group-hover/suggestion:text-brand transition-colors" />
+                                        </div>
+                                        <div className="flex flex-col overflow-hidden">
+                                            <span className="text-sm font-semibold truncate group-hover/suggestion:text-brand transition-colors">
+                                                {airport.name} <span className="text-content-muted font-normal group-hover/suggestion:text-content-muted transition-colors">({airport.iata_code})</span>
+                                            </span>
+                                            <span className="text-xs text-content-muted truncate opacity-70">
+                                                {airport.city}, {(airport.country && COUNTRY_NAMES[airport.country]?.[1]) || airport.country}
+                                            </span>
+                                        </div>
+                                    </li>
+                                ))}
                             </div>
-                            {airports.map((airport) => (
-                                <li
-                                    key={airport.iata_code}
-                                    className="px-4 py-3 hover:bg-surface transition-all cursor-pointer flex items-center gap-3 border-b border-line/40 last:border-0 group/suggestion"
-                                    onClick={() => handleSelect(airport)}
-                                >
-                                    <div className="bg-surface/50 p-2 rounded-xl shrink-0 group-hover/suggestion:bg-brand/10 transition-colors">
-                                        <Plane size={16} className="text-content-muted/60 group-hover/suggestion:text-brand transition-colors" />
-                                    </div>
-                                    <div className="flex flex-col overflow-hidden">
-                                        <span className="text-sm font-semibold truncate group-hover/suggestion:text-brand transition-colors">
-                                            {airport.name} <span className="text-content-muted font-normal group-hover/suggestion:text-content-muted transition-colors">({airport.iata_code})</span>
-                                        </span>
-                                        <span className="text-xs text-content-muted truncate opacity-70">
-                                            {airport.city}, {(airport.country && COUNTRY_NAMES[airport.country]?.[1]) || airport.country}
-                                        </span>
-                                    </div>
-                                </li>
-                            ))}
-                        </div>
-                    ))
-                ) : null}
+                        ))}
 
-                {/* Loading Indicator & Sentinel for Infinite Scroll */}
-                {(isFetching || isFetchingNextPage) ? (
+                        {hasNextPage && (
+                            <button
+                                onClick={() => setShowFlatList(true)}
+                                className="w-full py-3 text-xs font-bold text-brand hover:bg-brand/5 transition-colors uppercase tracking-wider border-t border-line/50 cursor-pointer"
+                            >
+                                Ver más resultados
+                            </button>
+                        )}
+                    </>
+                )}
+
+                {/* Flat view (Infinite Scroll) */}
+                {showFlatList && suggestions.map((airport) => (
+                    <li
+                        key={`${airport.iata_code}-flat`}
+                        className="px-4 py-3 hover:bg-surface transition-all cursor-pointer flex items-center gap-3 border-b border-line/40 last:border-0 group/suggestion"
+                        onClick={() => handleSelect(airport)}
+                    >
+                        <div className="bg-surface/50 p-2 rounded-xl shrink-0 group-hover/suggestion:bg-brand/10 transition-colors">
+                            <Plane size={16} className="text-content-muted/60 group-hover/suggestion:text-brand transition-colors" />
+                        </div>
+                        <div className="flex flex-col overflow-hidden">
+                            <span className="text-sm font-semibold truncate group-hover/suggestion:text-brand transition-colors">
+                                {airport.name} <span className="text-content-muted font-normal group-hover/suggestion:text-content-muted transition-colors">({airport.iata_code})</span>
+                            </span>
+                            <span className="text-xs text-content-muted truncate opacity-70">
+                                {airport.city}, {(airport.country && COUNTRY_NAMES[airport.country]?.[1]) || airport.country}
+                            </span>
+                        </div>
+                    </li>
+                ))}
+
+                {/* Loading Indicator & Sentinel for Infinite Scroll (Visible only in flat view or initial load) */}
+                {(isFetching || (showFlatList && isFetchingNextPage)) ? (
                     <div ref={sentinelRef} className="px-6 py-4 flex items-center justify-center gap-3 text-content-muted">
                         <Loader2 className="animate-spin h-5 w-5" />
                         <span className="text-xs">{isFetchingNextPage ? "Cargando más..." : "Buscando..."}</span>
                     </div>
-                ) : (debouncedQuery.length >= 2 && groupedSuggestions.length === 0) ? (
+                ) : (showFlatList && hasNextPage) ? (
+                    <div ref={sentinelRef} className="h-4 w-full" />
+                ) : (debouncedQuery.length >= 2 && suggestions.length === 0 && !isFetching) ? (
                     <div className="px-6 py-10 flex flex-col items-center justify-center gap-3 text-center">
                         <div className="bg-surface/50 p-4 rounded-3xl text-content-muted/40">
                             <Search size={32} />
@@ -227,7 +267,7 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
                             <p className="text-xs text-content-muted">Prueba con otro código o nombre de ciudad</p>
                         </div>
                     </div>
-                ) : <div ref={sentinelRef} />}
+                ) : null}
             </ul>
         </SmartPopover>
     );

--- a/frontend/src/components/AirportAutocomplete.tsx
+++ b/frontend/src/components/AirportAutocomplete.tsx
@@ -1,7 +1,9 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { Plane, Loader2, Search } from "lucide-react";
-import { useSearchAirports, useGetAirportByIata } from "@/api/generated/airports/airports";
-import type { AirportResponse } from "@/api/generated/model";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useGetAirportByIata } from "@/api/generated/airports/airports";
+import { customInstance } from "@/api/axios-instance";
+import type { AirportResponse, PaginatedAirportResponse } from "@/api/generated/model";
 import { COUNTRY_NAMES } from "@/constants/countries";
 import SmartPopover from "./ui/SmartPopover";
 
@@ -24,16 +26,28 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
     const [debouncedQuery, setDebouncedQuery] = useState("");
     const [isOpen, setIsOpen] = useState(false);
 
-    const { data, isFetching } = useSearchAirports(
-        { q: debouncedQuery },
-        {
-            query: {
-                enabled: debouncedQuery.length >= 2 && (!value || debouncedQuery !== getDisplay(value)),
-                staleTime: 5 * 60 * 1000,
-                refetchOnWindowFocus: false,
-            },
-        }
-    );
+    const sentinelRef = useRef<HTMLDivElement>(null);
+    const scrollContainerRef = useRef<HTMLUListElement>(null);
+
+    const {
+        data,
+        isFetching,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage
+    } = useInfiniteQuery({
+        queryKey: ['airports', 'autocomplete', debouncedQuery],
+        initialPageParam: 1,
+        queryFn: ({ pageParam }) => customInstance<PaginatedAirportResponse>({
+            url: '/airports',
+            method: 'GET',
+            params: { q: debouncedQuery, page: pageParam, limit: 20 }
+        }),
+        getNextPageParam: (lastPage) => lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+        enabled: debouncedQuery.length >= 2 && (!value || debouncedQuery !== getDisplay(value)),
+        staleTime: 5 * 60 * 1000,
+        refetchOnWindowFocus: false,
+    });
 
     // Resolve IATA code if only IATA is provided in value
     const shouldResolve = !!(value && value.iata_code && value.iata_code.length === 3 && !value.city && !value.name);
@@ -53,25 +67,7 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
         }
     }, [resolvedData, shouldResolve, onChange]);
 
-    // Resolve IATA code if only IATA is provided in value
-    const shouldResolve = !!(value && value.iata_code && value.iata_code.length === 3 && !value.city && !value.name);
-    const { data: resolvedData, isFetching: isResolving } = useGetAirportByIata(
-        value?.iata_code || "",
-        {
-            query: {
-                enabled: shouldResolve,
-                staleTime: Infinity,
-            }
-        }
-    );
-
-    useEffect(() => {
-        if (resolvedData && shouldResolve) {
-            onChange(resolvedData);
-        }
-    }, [resolvedData, shouldResolve, onChange]);
-
-    const suggestions = data?.items ?? [];
+    const suggestions = useMemo(() => data?.pages.flatMap(page => page.items) ?? [], [data]);
 
     const groupedSuggestions = useMemo(() => {
         const groups: Record<string, AirportResponse[]> = {};
@@ -107,6 +103,21 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
         }, 300);
         return () => clearTimeout(timer);
     }, [query, isOpen, value]);
+
+    // Infinite Scroll Observer
+    useEffect(() => {
+        const observer = new IntersectionObserver((entries) => {
+            if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+                fetchNextPage();
+            }
+        }, {
+            root: scrollContainerRef.current,
+            rootMargin: '100px'
+        });
+        const el = sentinelRef.current;
+        if (el) observer.observe(el);
+        return () => { if (el) observer.unobserve(el); };
+    }, [hasNextPage, isFetchingNextPage, fetchNextPage, suggestions, scrollContainerRef.current]);
 
     const handleSelect = (airport: AirportResponse) => {
         const result = onChange(airport);
@@ -168,7 +179,7 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
                 </div>
             }
         >
-            <ul className="flex flex-col">
+            <ul ref={scrollContainerRef} className="flex flex-col max-h-[400px] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
                 {groupedSuggestions.length > 0 ? (
                     groupedSuggestions.map(([country, airports]) => (
                         <div key={country} className="flex flex-col border-b border-line last:border-0">
@@ -198,7 +209,15 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
                             ))}
                         </div>
                     ))
-                ) : debouncedQuery.length >= 2 && !isFetching ? (
+                ) : null}
+
+                {/* Loading Indicator & Sentinel for Infinite Scroll */}
+                {(isFetching || isFetchingNextPage) ? (
+                    <div ref={sentinelRef} className="px-6 py-4 flex items-center justify-center gap-3 text-content-muted">
+                        <Loader2 className="animate-spin h-5 w-5" />
+                        <span className="text-xs">{isFetchingNextPage ? "Cargando más..." : "Buscando..."}</span>
+                    </div>
+                ) : (debouncedQuery.length >= 2 && groupedSuggestions.length === 0) ? (
                     <div className="px-6 py-10 flex flex-col items-center justify-center gap-3 text-center">
                         <div className="bg-surface/50 p-4 rounded-3xl text-content-muted/40">
                             <Search size={32} />
@@ -208,12 +227,7 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
                             <p className="text-xs text-content-muted">Prueba con otro código o nombre de ciudad</p>
                         </div>
                     </div>
-                ) : (
-                    <div className="px-6 py-10 flex items-center justify-center gap-3 text-content-muted">
-                        <Loader2 className="animate-spin h-5 w-5" />
-                        <span className="text-sm">Buscando aeropuertos...</span>
-                    </div>
-                )}
+                ) : <div ref={sentinelRef} />}
             </ul>
         </SmartPopover>
     );

--- a/frontend/src/components/AirportAutocomplete.tsx
+++ b/frontend/src/components/AirportAutocomplete.tsx
@@ -53,7 +53,25 @@ export default function AirportAutocomplete({ value, onChange, placeholder, clas
         }
     }, [resolvedData, shouldResolve, onChange]);
 
-    const suggestions = data ?? [];
+    // Resolve IATA code if only IATA is provided in value
+    const shouldResolve = !!(value && value.iata_code && value.iata_code.length === 3 && !value.city && !value.name);
+    const { data: resolvedData, isFetching: isResolving } = useGetAirportByIata(
+        value?.iata_code || "",
+        {
+            query: {
+                enabled: shouldResolve,
+                staleTime: Infinity,
+            }
+        }
+    );
+
+    useEffect(() => {
+        if (resolvedData && shouldResolve) {
+            onChange(resolvedData);
+        }
+    }, [resolvedData, shouldResolve, onChange]);
+
+    const suggestions = data?.items ?? [];
 
     const groupedSuggestions = useMemo(() => {
         const groups: Record<string, AirportResponse[]> = {};


### PR DESCRIPTION
- Airports and airlines endpoints now accept page and limit query parameters.
- Use InfiniteQuery instead of useSearchAirports to retrieve airports results in pages and show them when scrolling down in autocomplete component